### PR TITLE
Update to support Celery 5.x

### DIFF
--- a/async_downloads/tasks.py
+++ b/async_downloads/tasks.py
@@ -1,13 +1,13 @@
 import os
 
-from celery import task
+from celery import shared_task
 from django.core.cache import cache
 from django.core.files.storage import default_storage
 
 from async_downloads.settings import PATH_PREFIX
 
 
-@task()
+@shared_task()
 def cleanup_expired_downloads():
     """
     Delete expired downloads (where the download no longer exists in the cache).

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
Use the `@shared_task` decorator instead of `@task`, which is the recommended approach for celery 4.x and required for celery 5.x.