### PR TITLE
feat: Allow the downloads box to remain open between file deletions

### DIFF
--- a/async_downloads/templates/async_downloads/downloads.html
+++ b/async_downloads/templates/async_downloads/downloads.html
@@ -27,7 +27,8 @@
                 window.location.href = $dl.data("url");
             }
         });
-        $(".download-clear").on("click", function () {
+        $(".download-clear").on("click", function (e) {
+            e.stopPropagation();
             clearDownload($(this).closest(".download-container").data("filepath"));
         });
         $("#async-downloads [data-toggle='tooltip']").tooltip();


### PR DESCRIPTION
As an end user of the downloads package, sometimes I want to just wipe out a bunch of downloads.
The widow closing between clear actions makes isn't the most efficient UX.

Suggested change to the code as below to allow the window to remain open between clear actions.

Shouldn't have any impacts on functionality as I can't see any reason for there to be bubbled events.

Current:
https://user-images.githubusercontent.com/51363045/135067097-f49c0266-43ee-4da3-aa6f-f0fcb639f8ba.mp4


With no propogation:
https://user-images.githubusercontent.com/51363045/135067169-9ffcf24c-b39a-4474-940b-beac1c757629.mp4


