### PR TITLE
feat: add set_error message on download

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,13 @@ Arguments:
 - `collection_key`: the cache key of a collection of downloads
 
 
+### `cache.set_error`
+The asynchronous process can call this function to set an error message on the download.
+
+Arguments:
+- `download_key`: the cache key of this particular download
+- `error`: the error message to set
+
 #### `tasks.cleanup_expired_downloads`
 Delete expired downloads (where the download no longer exists in the cache).
 This is a clean up operation to prevent downloads that weren't manually deleted from building up,

--- a/async_downloads/cache.py
+++ b/async_downloads/cache.py
@@ -148,3 +148,22 @@ def cleanup_collection(collection_key):
     # cache.set(
     #     collection_key, [key for key in cache.get(collection_key, []) if cache.get(key) is not None]
     # )
+
+
+def set_error(download_key, error):
+    download = cache.get(download_key)
+    if not download:
+        return
+
+    logger.exception(
+        "Download failed with type: set_error key: %s name %s",
+        download_key,
+        download.get("name"),
+    )
+
+    download["errors"] = str(error)
+    download["complete"] = True
+    download["percentage"] = 100
+    cache.set(download_key, download, TIMEOUT)
+    if WS_MODE:
+        ws_update_download(download_key)


### PR DESCRIPTION
Allow the user to set an error message on the download for reasons that do not relate to an exception being raised with the iterable or file during processing.