### PR TITLE
fix: break logic early if user is anonymous

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ If package will be used in websockets mode additional settings must be applied.
 
 * Change in application template async-downloads section to use WS js version.
     ```
+    {{ user.is_anonymous|json_script:"IS_USER_ANONYMOUS" }}
     # example: FULL_WS_URL = "http://app.com/ws/downloads/"
     <script src="{% static "js/ws_async_downloads.js" %}" id="async-downloads-script"
         data-url="{{ FULL_WS_URL }}"
@@ -97,6 +98,8 @@ If package will be used in websockets mode additional settings must be applied.
         and it must include the protocol because the `ws_async_downloads.js` script will 
         inspect it to determine which WebSockets protocol to use - `ws` if `http` or `wss` 
         if `https`.
+    - `IS_USER_ANONYMOUS` is a boolean that will be used to determine if the user is anonymous
+        and should not have access to the async download centre.
 
 * Configure `CHANNEL_LAYERS` inside common settings. Example config:
     ```

--- a/async_downloads/static/js/ws_async_downloads.js
+++ b/async_downloads/static/js/ws_async_downloads.js
@@ -1,4 +1,8 @@
 $(function () {
+    if (document.querySelector("#IS_USER_ANONYMOUS") !== null && document.querySelector("#IS_USER_ANONYMOUS").textContent === "true") {
+        return;
+    }
+
     function readablePeriod(timeStamp) {
         // timeStamp should consist information about timezone
         const diff = Date.now() - Date.parse(timeStamp);

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='django-async-downloads',
-    version='0.5.2',
+    version='0.6.0',
     author='David Vaughan',
     author_email='david.vaughan@quickrelease.co.uk',
     maintainer="Quick Release (Automotive) Ltd.",


### PR DESCRIPTION
Equivalent of https://github.com/QuickRelease/notifiqrations/pull/4.
Doing this in a backwards compatible way, so if `IS_USER_ANONYMOUS` isnt set, it will work as it used to.

https://quickrelease.sentry.io/issues/6030907396/?project=4507604976336896&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=1h&stream_index=1